### PR TITLE
Minor typographical/formatting edits

### DIFF
--- a/1.FirstSteps.tex
+++ b/1.FirstSteps.tex
@@ -462,7 +462,7 @@ Now %
 \sidepar{As before in H\amp\ K, we make no claim that the semantic
   values that are attributed to expressions in our framework fully
   capture what is informally meant by ``meaning''. But certainly,
-  intensions come close to ``meaning'' than extensions.}%
+  intensions come closer to ``meaning'' than extensions.}%
 let's spell that account out. Our system actually provides us with two
 kinds of meanings. For any expression $\alpha$, we have
 $\sv{\alpha}^{w,g}$, the semantic value of $\alpha$ in $w$, also known
@@ -514,12 +514,12 @@ It %
 should be noted that the terminology of \term{extension} vs.
 \term{intension} is time-honored but that the possible worlds
 interpretation thereof is more recent. The technical notion we are
-using is certainly less rich a notion of meaning than tradition
+using is certainly less rich a notion of meaning than traditionally
 assumed.\footnote{For example, Frege's ``modes of presentation'' are
   not obviously captured by this possible worlds implementation of
   extension/intension.}
 
-\subsubsection{Step 8: Semantic Types and Semantics Domains.} \label{sec:semantic-types}
+\subsubsection{Step 8: Semantic Types and Semantic Domains.} \label{sec:semantic-types}
 
 If we want to be able to feed the intensions to lexical items like
 \expression{in the world of Sherlock Holmes}, we need to have the
@@ -756,7 +756,7 @@ make \term{contingent} claims, claims that are true or false depending
 on the circumstances in the actual world.
 
 Our example sentence \expression{In the world of Sherlock Holmes, a
-  famous detective lives at 221 Baker Street} is true in this world
+  famous detective lives at 221B Baker Street} is true in this world
 but it could easily have been false. There is no reason why Sir Arthur
 Conan Doyle could not have decided to locate Holmes' abode on Abbey
 Road.
@@ -820,7 +820,7 @@ that this is sloppy talk. \citet{lewis:1978:fiction} writes:
 %
 The usual move at this point is to talk about the set of worlds
 ``\term{compatible with} the (content of) Sherlock Holmes stories in
-w''. We imagine that we ask of each possible world whether what is
+$w$''. We imagine that we ask of each possible world whether what is
 going on in it is compatible with the stories as they were written in
 our world. Worlds where Holmes lives on Abbey Road are not compatible.
 Some worlds where he lives at 221B Baker Street are compatible (again

--- a/2.Conditionals-First.tex
+++ b/2.Conditionals-First.tex
@@ -101,7 +101,7 @@ exacting standards? Is it propped up by its neighbors? Does Harry Potter owe me
 a favor?
 
 We can build dependence on the evaluation world in by saying that \emph{if} only
-operates on worlds that are ``relevant like'' the evaluation world:
+operates on worlds that are ``relevantly like'' the evaluation world:
 
 \ex.\label{ex:if-strict-context} $\sv{\mbox{if}}^{w,g} = \lambda p \in D_{\angles{s,t}}.\ \lambda q \in
 D_{\angles{s,t}}.$ \\ \null\hfill $\forall w'\co p(w')=1\ \&\ w' \text{ is
@@ -114,8 +114,8 @@ rather vague and context-dependent doesn't mean it is wrong. As
 
 \begin{quote} Counterfactuals are notoriously vague. That does not mean that we
 cannot give a clear account of their truth conditions. It does mean that such an
-account must either be stated in vague terms-which does not mean ill-understood
-terms-or be made relative to some parameter that is fixed only within rough
+account must either be stated in vague terms---which does not mean ill-understood
+terms---or be made relative to some parameter that is fixed only within rough
 limits on any given occasion of language use.
 \end{quote}
 

--- a/3.Modals.tex
+++ b/3.Modals.tex
@@ -41,7 +41,7 @@ lowest copy in the movement chain.\sidepar{We will talk about
   reconstruction in more detail later.}) We will be able to prove that
 movement of a name or pronoun never affects truth-conditions, so at
 any rate the interpretation of the structure in \Last[b] would be the
-same as of \Next. As a matter of convenience, then, we will take the
+same as that of \Next. As a matter of convenience, then, we will take the
 reconstructed structures, which allow us to abstract away from the
 (here irrelevant) mechanics of variable binding.
 
@@ -59,7 +59,7 @@ take a full sentence as their semantic argument.\footnote{We will
 \subsection{Quantification over Possible Worlds} \label{sec:quant-over-poss}
 
 The\sidepar{This idea goes back a long time. It was famously held
-  by Leibniz, but there are precedents in the medieval literature, see
+  by Leibniz, but there are precedents in the medieval literature; see
   \citet{knuuttila:2003:modality-medieval}. See
   \citet{copeland:2002:genesis} for the modern history of the possible
   worlds analysis of modal expressions.} basic idea of the possible
@@ -90,7 +90,7 @@ Therefore, you must stay. \hfill\textsc{invalid}
 
 \ex. \a. You may stay, but it is not the case that you must
 stay.\footnote{The somewhat stilted \expression{it is not the
-    case}-construction is used in to make certain that negation takes
+    case}-construction is used in (a) to make certain that negation takes
   scope over \expression{must}. When modal auxiliaries and negation
   are together in the auxiliary complex of the same clause, their
   relative scope seems not to be transparently encoded in the surface
@@ -152,7 +152,7 @@ prove.\marginnote{More linguistic data regarding the ``parallel
   logic'' of modals and quantifiers can be found in Larry Horn's
   dissertation \citep{horn:1972:dissertation}.}
 
-\ex. \a. $\forall x \phi \equiv \neg \exists \neg \phi$ \b. $\forall x \neg \phi \equiv \neg \exists x \phi$
+\ex. \a. $\forall x \phi \equiv \neg \exists x \neg \phi$ \b. $\forall x \neg \phi \equiv \neg \exists x \phi$
 
 \ex. \a. $\exists x \phi \equiv \neg \forall x \neg \phi$ \b. $\exists x \neg \phi \equiv \neg \forall x \phi$
 
@@ -323,7 +323,7 @@ this:
 \exi. \label{newlf} [I$'$ [I must $p_{\angles{n,\angles{s,t}}}$ ] [VP you quiet]]
 
 \sidepar{We are using the notation for variables of types other than
-  $e$, introduced by Heim \amp\ Kratzer. See p. 213. An index on a
+  $e$ introduced by Heim \amp\ Kratzer. See p. 213. An index on a
   variable now is an ordered pair of a natural number and a type.
   \\[\baselineskip] Q: Can you think of overt anaphoric expressions
   that are arguably of the type $\angles{s,t}$, a proposition?}%
@@ -494,9 +494,9 @@ And the new lexical entries for \expression{must} and \expression{may}
 that will fit this new structure are these:
 
 \ex. \a. \exts{must} = \exts{have-to} = \exts{need-to} = \dots{} =\\
-$\lambda R\in D_{\angles{s,st}}.\ \lambda q\in D_{\angles{s,t}}.\ \forall w'\in W\ [R(w)(w') =1 \rightarrow q(w')=1]$\marginnote{in set talk: $(R(w)\ensuremath{\subseteq}q$}
+$\lambda R\in D_{\angles{s,st}}.\ \lambda q\in D_{\angles{s,t}}.\ \forall w'\in W\ [R(w)(w') =1 \rightarrow q(w')=1]$\marginnote{in set talk: $R(w)\ensuremath{\subseteq}q$}
 \b. \exts{may} = \exts{can} = \exts{be-allowed-to} = \dots{} =\\
-$\lambda R\in D_{\angles{s,st}}.\ \lambda q\in D_{\angles{s,t}}.\ \exists w'\in W\ [R(w)(w')=1\ \&\ q(w')=1]$\marginnote{in set talk: $(R(w)\ensuremath{\cap}q\ensuremath{\neq}\ensuremath{\emptyset}$}
+$\lambda R\in D_{\angles{s,st}}.\ \lambda q\in D_{\angles{s,t}}.\ \exists w'\in W\ [R(w)(w')=1\ \&\ q(w')=1]$\marginnote{in set talk: $R(w)\ensuremath{\cap}q\ensuremath{\neq}\ensuremath{\emptyset}$}
 
 Let us see now how this solves the contingency problem.
 
@@ -609,7 +609,7 @@ extensions of type \angles{\angles{s,st}, \angles{st,t}}:
 \ex. (repeated from earlier):\\
 For any $w \in W$: \exts{must}\\
 $\lambda R\in D_{\angles{s,st}}.\ \lambda q\in D_{\angles{s,t}}.\ \forall w'\in W\ [R(w)(w') =1 \rightarrow q(w')=1]$\\
-\null\hfill(in set talk: $\lambda R_{\angles{s,st}}.\ \lambda q_{\angles{s,t}}.\ (R(w)\ensuremath{\subseteq}q)$).
+\null\hfill(in set talk: $\lambda R_{\angles{s,st}}.\ \lambda q_{\angles{s,t}}.\ R(w)\ensuremath{\subseteq}q$).
 
 Unfortunately, this treatment somewhat obscures the parallel between
 the modals and the quantificational determiners, which have
@@ -626,7 +626,7 @@ modals at first:
 
 We posit the following LF-representation:
 
-\exi. \label{brandlf} [I$'$ [I must [ $R_{\angles{4,\angles{s,st}}}$ w*]] [VP you quiet]]
+\exi. \label{brandlf} [I$'$ [I must [ $R_{\angles{4,\angles{s,st}}}\ w*$]] [VP you quiet]]
 
 What is new here is that the covert restrictor is complex. The first
 part, $R_{\angles{4,\angles{s,st}}}$, is (as before) a free variable
@@ -641,7 +641,7 @@ picking out the evaluation world:
 
 \ex. For any $w\in W: \sv{w*}^{w,g} = w$.\footnote{\citet{dowty:1982:time-adverbs} introduced an analogous symbol to pick out the evaluation \emph{time}. We have chosen the star-notation to allude to this precedent.}
 
-When $R_{\angles{4,\angles{s,st}}}$ and \expression{w*} combine (by
+When $R_{\angles{4,\angles{s,st}}}$ and $w*$ combine (by
 Functional Application), we obtain a constituent whose extension is of
 type \angles{s,t} (a proposition or set of worlds). This is the same
 type as the extension of the free variable $p$ in the previous
@@ -652,7 +652,7 @@ evaluation world, the new complex constituent's extension depends on
 both the assignment and the world:
 
 \ex. For any $w\in W$ and any assignment $g$: \\
-\exts[w,g]{$R_{\angles{4,\angles{s,st}}}$(w*)} = g(\angles{4,\angles{s,st}})($w$).
+\exts[w,g]{$R_{\angles{4,\angles{s,st}}}\ w*$} = g(\angles{4,\angles{s,st}})($w$).
 
 As a consequence of this, the extensions of the higher nodes I and
 I$'$ will also vary with the evaluation world, and this is how we

--- a/6.Attitudes.tex
+++ b/6.Attitudes.tex
@@ -229,12 +229,12 @@ itself. Which accessibility relations are reflexive? Take knowledge:
 
 \ex. $w\mathcal{R}^{\mathcal{K}}_{x}w'$ iff $w'$ is compatible with what $x$ knows in $w$.
 
-We%
+We %
 \sidepar{We talk here about knowledge entailing (or even presupposing)
   truth but we do not mean to say that knowledge simply equals true
   belief. Professors Socrates and Gettier and their exegetes have
   further considerations.}%
- are asking whether for any given possible world $w$, we know that
+are asking whether for any given possible world $w$, we know that
 $\mathcal{R}^{\mathcal{K}}_{x}$ holds between $w$ and $w$ itself. It
 will hold if $w$ is a world that is compatible with what we know in
 $w$. And clearly that must be so. Take our body of knowledge in $w$. The concept of knowledge crucially contains the concept of truth: what

--- a/6.Attitudes.tex
+++ b/6.Attitudes.tex
@@ -300,7 +300,7 @@ directions.
 \noindent What does it take for the pattern to be valid? Assume that
 $\square p$ holds for an arbitrary world $w$, i.e. that $p$ is true in
 all worlds $w'$ accessible from $w$. Now, the inference is to the fact
-that $\square p$ again holds in any world $w''$ accessible from any of
+that $p$ again holds in any world $w''$ accessible from any of
 those worlds $w'$ accessible from $w$. But what would prevent $p$ from
 being false in some $w''$ accessible from some $w'$ accessible from
 $w$? That could only be prevented from happening if we knew that $w''$


### PR DESCRIPTION
This is a set of 5 commits: 1 each containing typographical/formatting fixes for chapters 1, 2, 3, and 6, and 1 containing a contentful change in the Transitivity section of chapter 6 (cf. fall 2013 email correspondence).